### PR TITLE
adding bulk endpoints and auth token endpoint

### DIFF
--- a/skeletonservice/datasets/api.py
+++ b/skeletonservice/datasets/api.py
@@ -13,7 +13,7 @@ from meshparty import skeleton
 from skeletonservice.datasets import schemas
 from skeletonservice.datasets import limiter
 from skeletonservice.datasets.limiter import *
-from skeletonservice.datasets.service import NEUROGLANCER_SKELETON_VERSION, SKELETON_DEFAULT_VERSION_PARAMS, SKELETON_VERSION_PARAMS, SkeletonService
+from skeletonservice.datasets.service import NEUROGLANCER_SKELETON_VERSION, SKELETON_DEFAULT_VERSION_PARAMS, SKELETON_VERSION_PARAMS, SkeletonService, MAX_BULK_CACHED_SKELETONS
 
 from middle_auth_client import (
     auth_required,
@@ -909,5 +909,86 @@ class SkeletonResource__gen_skeletons_bulk_async_C(Resource):
         t1_et = t1 - t0
         t2_et = t2 - t1
         SkeletonService.print(f"SkeletonResource__gen_skeletons_bulk_async_C() Elapsed times: {t1_et:.3f}s {t2_et:.3f}s")
-        
+
         return response
+
+
+@api_bp.route("/<string:datastack_name>/bulk/get_cached_skeletons/<int(signed=True):skvn>/<string:output_format>")
+class SkeletonResource__get_cached_skeletons_bulk(Resource):
+    """Retrieve only already-cached skeletons in bulk, up to MAX_BULK_CACHED_SKELETONS at a time.
+    Unlike get_skeletons_bulk, this endpoint skips per-RID CAVEclient validation and never blocks
+    on skeleton generation. Returns skeletons that exist, plus lists of missing and async-queued RIDs."""
+    method_decorators = [
+        limit_by_category("get_cached_skeletons_bulk"),
+        auth_requires_permission("view", table_arg="datastack_name"),
+    ]
+
+    @staticmethod
+    def process(datastack_name: str, skvn: int, output_format: str, rids: list, generate_missing: bool, verbose_level: int = 0):
+        SkelClassVsn = SkeletonService.get_version_specific_handler(skvn)
+
+        return SkelClassVsn.get_cached_skeletons_bulk_by_datastack_and_rids(
+            datastack_name,
+            rids=rids,
+            bucket=current_app.config["SKELETON_CACHE_BUCKET"],
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=skvn,
+            output_format=output_format,
+            generate_missing_skeletons=generate_missing,
+            session_timestamp_=SkeletonService.get_session_timestamp(),
+            verbose_level_=verbose_level,
+        )
+
+    @api_bp.doc("SkeletonResource__get_cached_skeletons_bulk", security="apikey")
+    @auth_required
+    @auth_requires_permission("view", table_arg="datastack_name", resource_namespace="datastack")
+    def post(self, datastack_name: str, skvn: int, output_format: str):
+        data = request.json
+        rids = data["root_ids"]
+        generate_missing = bool(data.get("generate_missing", False))
+        verbose_level = int(data.get("verbose_level", 0))
+        verbose_level = max(int(request.args.get("verbose_level", 0)), verbose_level)
+        return self.process(datastack_name, skvn, output_format, rids, generate_missing, verbose_level)
+
+
+@api_bp.route("/<string:datastack_name>/bulk/get_skeleton_token/<int(signed=True):skvn>")
+class SkeletonResource__get_skeleton_token(Resource):
+    """Generate a short-lived downscoped GCS access token for direct skeleton downloads.
+    The token is scoped to read-only access on the skeleton bucket prefix for the given
+    datastack and skeleton version. The response includes GCS object paths for each
+    requested RID that exists in the cache, so the client can download files directly
+    without going through this service."""
+    method_decorators = [
+        limit_by_category("get_skeleton_token_bulk"),
+        auth_requires_permission("view", table_arg="datastack_name"),
+    ]
+
+    @staticmethod
+    def process(datastack_name: str, skvn: int, rids: list, expiration_minutes: int, verbose_level: int = 0):
+        SkelClassVsn = SkeletonService.get_version_specific_handler(skvn)
+
+        return SkelClassVsn.get_skeleton_token_by_datastack_and_rids(
+            datastack_name,
+            rids=rids,
+            bucket=current_app.config["SKELETON_CACHE_BUCKET"],
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=skvn,
+            expiration_minutes=expiration_minutes,
+            session_timestamp_=SkeletonService.get_session_timestamp(),
+            verbose_level_=verbose_level,
+        )
+
+    @api_bp.doc("SkeletonResource__get_skeleton_token", security="apikey")
+    @auth_required
+    @auth_requires_permission("view", table_arg="datastack_name", resource_namespace="datastack")
+    def post(self, datastack_name: str, skvn: int):
+        data = request.json
+        rids = data["root_ids"]
+        expiration_minutes = int(data.get("expiration_minutes", 60))
+        verbose_level = int(data.get("verbose_level", 0))
+        verbose_level = max(int(request.args.get("verbose_level", 0)), verbose_level)
+        return self.process(datastack_name, skvn, rids, expiration_minutes, verbose_level)

--- a/skeletonservice/datasets/api.py
+++ b/skeletonservice/datasets/api.py
@@ -957,27 +957,25 @@ class SkeletonResource__get_cached_skeletons_bulk(Resource):
 class SkeletonResource__get_skeleton_token(Resource):
     """Generate a short-lived downscoped GCS access token for direct skeleton downloads.
     The token is scoped to read-only access on the skeleton bucket prefix for the given
-    datastack and skeleton version. The response includes GCS object paths for each
-    requested RID that exists in the cache, so the client can download files directly
-    without going through this service."""
+    datastack and skeleton version (60-minute lifetime, the GCP IAM maximum). The response
+    includes a path_template with a {rid} placeholder so the client can construct per-file
+    object paths without knowing the server-side naming convention."""
     method_decorators = [
         limit_by_category("get_skeleton_token_bulk"),
         auth_requires_permission("view", table_arg="datastack_name"),
     ]
 
     @staticmethod
-    def process(datastack_name: str, skvn: int, rids: list, expiration_minutes: int, verbose_level: int = 0):
+    def process(datastack_name: str, skvn: int, verbose_level: int = 0):
         SkelClassVsn = SkeletonService.get_version_specific_handler(skvn)
 
-        return SkelClassVsn.get_skeleton_token_by_datastack_and_rids(
+        return SkelClassVsn.get_skeleton_token_by_datastack(
             datastack_name,
-            rids=rids,
             bucket=current_app.config["SKELETON_CACHE_BUCKET"],
             root_resolution=[1, 1, 1],
             collapse_soma=True,
             collapse_radius=7500,
             skeleton_version=skvn,
-            expiration_minutes=expiration_minutes,
             session_timestamp_=SkeletonService.get_session_timestamp(),
             verbose_level_=verbose_level,
         )
@@ -986,9 +984,7 @@ class SkeletonResource__get_skeleton_token(Resource):
     @auth_required
     @auth_requires_permission("view", table_arg="datastack_name", resource_namespace="datastack")
     def post(self, datastack_name: str, skvn: int):
-        data = request.json
-        rids = data["root_ids"]
-        expiration_minutes = int(data.get("expiration_minutes", 60))
+        data = request.json or {}
         verbose_level = int(data.get("verbose_level", 0))
         verbose_level = max(int(request.args.get("verbose_level", 0)), verbose_level)
-        return self.process(datastack_name, skvn, rids, expiration_minutes, verbose_level)
+        return self.process(datastack_name, skvn, verbose_level)

--- a/skeletonservice/datasets/api.py
+++ b/skeletonservice/datasets/api.py
@@ -947,6 +947,8 @@ class SkeletonResource__get_cached_skeletons_bulk(Resource):
     def post(self, datastack_name: str, skvn: int, output_format: str):
         data = request.json
         rids = data["root_ids"]
+        if len(rids) > MAX_BULK_CACHED_SKELETONS:
+            return {"Error": f"Too many root IDs requested: {len(rids)}. Maximum allowed is {MAX_BULK_CACHED_SKELETONS}."}, 400
         generate_missing = bool(data.get("generate_missing", False))
         verbose_level = int(data.get("verbose_level", 0))
         verbose_level = max(int(request.args.get("verbose_level", 0)), verbose_level)

--- a/skeletonservice/datasets/service.py
+++ b/skeletonservice/datasets/service.py
@@ -2465,18 +2465,16 @@ class SkeletonService:
         if messaging_client is not None:
             messaging_client.close()
 
-        return {"skeletons": skeletons, "missing": missing, "async_queued": async_queued}
+        return skeletons
 
     @staticmethod
-    def get_skeleton_token_by_datastack_and_rids(
+    def get_skeleton_token_by_datastack(
         datastack_name: str,
-        rids: List,
         bucket: str,
         root_resolution: List,
         collapse_soma: bool,
         collapse_radius: int,
         skeleton_version: int = 0,
-        expiration_minutes: int = 60,
         session_timestamp_: str = "not_provided",
         verbose_level_: int = 0,
     ):
@@ -2484,18 +2482,18 @@ class SkeletonService:
         Generate a short-lived downscoped GCS access token that authorizes the caller to
         download skeleton H5 files directly from the GCS bucket, bypassing this service.
 
-        The token is scoped to read-only access on the specific bucket prefix for the
-        given datastack and skeleton version. The response includes the object paths for
-        all requested RIDs that exist in the cache, so the client can construct GCS
-        download URLs without needing to know the file naming convention.
+        The token is scoped to read-only access on the skeleton prefix for the given
+        datastack and skeleton version (60-minute lifetime, the GCP IAM maximum).
+
+        Also returns a path_template with a {rid} placeholder so the client can construct
+        per-file object paths without needing to know the server-side naming convention.
 
         Returns a dict:
-          "token":        short-lived Bearer token
-          "token_type":   "Bearer"
-          "expiry":       ISO-8601 expiry datetime string
-          "bucket":       GCS bucket name (without gs:// scheme)
-          "object_paths": {rid: GCS object path within the bucket}
-          "missing":      [rids not found in cache]
+          "token":         short-lived Bearer token
+          "token_type":    "Bearer"
+          "expiry":        ISO-8601 expiry datetime string
+          "bucket":        GCS bucket name (without gs:// scheme)
+          "path_template": GCS object path with {rid} placeholder
         """
         global session_timestamp, verbose_level
 
@@ -2509,7 +2507,7 @@ class SkeletonService:
 
         if verbose_level >= 1:
             SkeletonService.print(
-                f"get_skeleton_token_by_datastack_and_rids() datastack_name: {datastack_name}, rids: {rids}, bucket: {bucket}, skeleton_version: {skeleton_version}, expiration_minutes: {expiration_minutes}",
+                f"get_skeleton_token_by_datastack() datastack_name: {datastack_name}, bucket: {bucket}, skeleton_version: {skeleton_version}",
             )
 
         # Parse "gs://bucket-name/" or "gs://bucket-name/extra/prefix/" into components
@@ -2521,34 +2519,18 @@ class SkeletonService:
         datastack_name_remapped = DATASTACK_NAME_REMAPPING[datastack_name] if datastack_name in DATASTACK_NAME_REMAPPING else datastack_name
         skvn_prefix = f"{bucket_extra_prefix}{datastack_name_remapped}/{HIGHEST_SKELETON_VERSION}/"
 
-        # Check which requested RIDs exist in the cache
-        object_paths = {}
-        missing = []
-
-        for rid in rids:
-            params_cached = [
-                rid,
-                bucket,
-                HIGHEST_SKELETON_VERSION,
-                datastack_name,
-                root_resolution,
-                collapse_soma,
-                collapse_radius,
-            ]
-
-            if SkeletonService._check_root_id_against_refusal_list(bucket, datastack_name, rid):
-                missing.append(rid)
-                continue
-
-            h5_available = SkeletonService._confirm_skeleton_in_cache(params_cached, "h5")
-            if verbose_level >= 1:
-                SkeletonService.print(f"get_skeleton_token_by_datastack_and_rids() H5 availability for rid {rid}: {h5_available}")
-
-            if h5_available:
-                file_name = SkeletonService._get_skeleton_filename(*params_cached, "h5")
-                object_paths[rid] = skvn_prefix + file_name
-            else:
-                missing.append(rid)
+        # Build path template: client substitutes {rid} for each root ID
+        template_params = [
+            "{rid}",
+            bucket,
+            HIGHEST_SKELETON_VERSION,
+            datastack_name,
+            root_resolution,
+            collapse_soma,
+            collapse_radius,
+        ]
+        file_name_template = SkeletonService._get_skeleton_filename(*template_params, "h5")
+        path_template = skvn_prefix + file_name_template
 
         # Generate a downscoped access token scoped to the skeleton prefix in this bucket
         credentials, _ = google.auth.default()
@@ -2575,8 +2557,7 @@ class SkeletonService:
             "token_type": "Bearer",
             "expiry": expiry_str,
             "bucket": bucket_name,
-            "object_paths": {str(rid): path for rid, path in object_paths.items()},
-            "missing": missing,
+            "path_template": path_template,
         }
 
     @staticmethod

--- a/skeletonservice/datasets/service.py
+++ b/skeletonservice/datasets/service.py
@@ -2,6 +2,9 @@ import ast
 import copy
 from io import BytesIO
 import binascii
+import google.auth
+import google.auth.downscoped
+import google.auth.transport.requests
 import google.cloud.logging
 import logging
 import math
@@ -43,6 +46,7 @@ DEBUG_MINIMIZE_JSON_SKELETON = False  # DEBUG: See _minimize_json_skeleton_for_e
 DEBUG_DEAD_LETTER_TEST_RID = 102030405060708090  # This root will always immediately trigger an exception when skeletonizing, which will send it to the dead letter queue
 COMPRESSION = "gzip"  # Valid values mirror cloudfiles.CloudFiles.put() and put_json(): None, 'gzip', 'br' (brotli), 'zstd'
 MAX_BULK_SYNCHRONOUS_SKELETONS = 10
+MAX_BULK_CACHED_SKELETONS = 500  # Higher limit: only reading from cache, not generating
 PUBSUB_BATCH_SIZE = 100
 # We have to clean up escape characters in DATASTACK_NAME_REMAPPING because the curly brackets of the inner dictionary are escaped when bash-serializing in the PrinceAllenCAVE scripts
 DATASTACK_NAME_REMAPPING = ast.literal_eval(os.environ.get('SKELETON_DATASTACK_NAME_REMAPPING', '{}').replace("\\", ""))
@@ -2338,7 +2342,243 @@ class SkeletonService:
         messaging_client.close()
 
         return skeletons
-    
+
+    @staticmethod
+    def get_cached_skeletons_bulk_by_datastack_and_rids(
+        datastack_name: str,
+        rids: List,
+        bucket: str,
+        root_resolution: List,
+        collapse_soma: bool,
+        collapse_radius: int,
+        skeleton_version: int = 0,
+        output_format: str = "flatdict",
+        generate_missing_skeletons: bool = False,
+        session_timestamp_: str = "not_provided",
+        verbose_level_: int = 0,
+    ):
+        """
+        Retrieve only already-cached skeletons in bulk, with a higher RID limit than
+        get_skeletons_bulk_by_datastack_and_rids(). Skips per-RID CAVEclient validation
+        to avoid blocking on chunkedgraph network calls.
+
+        Returns a dict with three keys:
+          "skeletons": {rid: hex-encoded compressed skeleton data}
+          "missing":   [rids not found in cache and not queued]
+          "async_queued": [rids not in cache that were queued for async generation]
+        """
+        global session_timestamp, verbose_level
+
+        session_timestamp = session_timestamp_
+
+        if verbose_level_ > verbose_level:
+            verbose_level = verbose_level_
+
+        if bucket[-1] != "/":
+            bucket += "/"
+
+        if verbose_level >= 1:
+            SkeletonService.print(
+                f"get_cached_skeletons_bulk_by_datastack_and_rids() datastack_name: {datastack_name}, rids: {rids}, bucket: {bucket}, skeleton_version: {skeleton_version}",
+                f" root_resolution: {root_resolution}, collapse_soma: {collapse_soma}, collapse_radius: {collapse_radius}, output_format: {output_format}, generate_missing_skeletons: {generate_missing_skeletons}",
+            )
+
+        assert (output_format == "flatdict" or output_format == "json" or output_format == "swc" or output_format == "jsoncompressed" or output_format == "swccompressed")
+        if (output_format == "json" or output_format == "swc"):
+            output_format += "compressed"
+
+        if len(rids) > MAX_BULK_CACHED_SKELETONS:
+            rids = rids[:MAX_BULK_CACHED_SKELETONS]
+            if verbose_level >= 1:
+                SkeletonService.print(f"get_cached_skeletons_bulk_by_datastack_and_rids() Truncating rids to {MAX_BULK_CACHED_SKELETONS}")
+
+        messaging_client = MessagingClientPublisher(PUBSUB_BATCH_SIZE) if generate_missing_skeletons else None
+
+        skeletons = {}
+        missing = []
+        async_queued = []
+
+        for rid in rids:
+            params_cached = [
+                rid,
+                bucket,
+                HIGHEST_SKELETON_VERSION,
+                datastack_name,
+                root_resolution,
+                collapse_soma,
+                collapse_radius,
+            ]
+
+            if SkeletonService._check_root_id_against_refusal_list(bucket, datastack_name, rid):
+                missing.append(rid)
+                continue
+
+            skeleton = SkeletonService._retrieve_skeleton_from_cache(params_cached, output_format)
+            if verbose_level >= 1:
+                SkeletonService.print(f"get_cached_skeletons_bulk_by_datastack_and_rids() Cache query result for {output_format} rid {rid}: {skeleton is not None}")
+
+            if skeleton is None:
+                h5_available = SkeletonService._confirm_skeleton_in_cache(params_cached, "h5")
+                if verbose_level >= 1:
+                    SkeletonService.print(f"H5 availability for rid {rid}: {h5_available}")
+                if h5_available:
+                    skeleton = SkeletonService.get_skeleton_by_datastack_and_rid(
+                        datastack_name,
+                        rid,
+                        output_format,
+                        bucket,
+                        root_resolution,
+                        collapse_soma,
+                        collapse_radius,
+                        skeleton_version,
+                        False,
+                        session_timestamp,
+                        verbose_level_,
+                    )
+                if not h5_available:
+                    if generate_missing_skeletons:
+                        SkeletonService.publish_skeleton_request(
+                            messaging_client,
+                            datastack_name,
+                            rid,
+                            "none",
+                            bucket,
+                            root_resolution,
+                            collapse_soma,
+                            collapse_radius,
+                            skeleton_version,
+                            True,
+                            verbose_level_,
+                        )
+                        async_queued.append(rid)
+                    else:
+                        missing.append(rid)
+                    continue
+
+            if output_format == "flatdict":
+                skeletons[rid] = binascii.hexlify(skeleton).decode('ascii')
+            elif output_format == "jsoncompressed":
+                skeletons[rid] = binascii.hexlify(skeleton).decode('ascii')
+            elif output_format == "swccompressed":
+                skeletons[rid] = binascii.hexlify(skeleton.getvalue()).decode('ascii')
+
+        if messaging_client is not None:
+            messaging_client.close()
+
+        return {"skeletons": skeletons, "missing": missing, "async_queued": async_queued}
+
+    @staticmethod
+    def get_skeleton_token_by_datastack_and_rids(
+        datastack_name: str,
+        rids: List,
+        bucket: str,
+        root_resolution: List,
+        collapse_soma: bool,
+        collapse_radius: int,
+        skeleton_version: int = 0,
+        expiration_minutes: int = 60,
+        session_timestamp_: str = "not_provided",
+        verbose_level_: int = 0,
+    ):
+        """
+        Generate a short-lived downscoped GCS access token that authorizes the caller to
+        download skeleton H5 files directly from the GCS bucket, bypassing this service.
+
+        The token is scoped to read-only access on the specific bucket prefix for the
+        given datastack and skeleton version. The response includes the object paths for
+        all requested RIDs that exist in the cache, so the client can construct GCS
+        download URLs without needing to know the file naming convention.
+
+        Returns a dict:
+          "token":        short-lived Bearer token
+          "token_type":   "Bearer"
+          "expiry":       ISO-8601 expiry datetime string
+          "bucket":       GCS bucket name (without gs:// scheme)
+          "object_paths": {rid: GCS object path within the bucket}
+          "missing":      [rids not found in cache]
+        """
+        global session_timestamp, verbose_level
+
+        session_timestamp = session_timestamp_
+
+        if verbose_level_ > verbose_level:
+            verbose_level = verbose_level_
+
+        if bucket[-1] != "/":
+            bucket += "/"
+
+        if verbose_level >= 1:
+            SkeletonService.print(
+                f"get_skeleton_token_by_datastack_and_rids() datastack_name: {datastack_name}, rids: {rids}, bucket: {bucket}, skeleton_version: {skeleton_version}, expiration_minutes: {expiration_minutes}",
+            )
+
+        # Parse "gs://bucket-name/" or "gs://bucket-name/extra/prefix/" into components
+        bucket_without_scheme = bucket.removeprefix("gs://").rstrip("/")
+        parts = bucket_without_scheme.split("/", 1)
+        bucket_name = parts[0]
+        bucket_extra_prefix = (parts[1] + "/") if len(parts) > 1 else ""
+
+        datastack_name_remapped = DATASTACK_NAME_REMAPPING[datastack_name] if datastack_name in DATASTACK_NAME_REMAPPING else datastack_name
+        skvn_prefix = f"{bucket_extra_prefix}{datastack_name_remapped}/{HIGHEST_SKELETON_VERSION}/"
+
+        # Check which requested RIDs exist in the cache
+        object_paths = {}
+        missing = []
+
+        for rid in rids:
+            params_cached = [
+                rid,
+                bucket,
+                HIGHEST_SKELETON_VERSION,
+                datastack_name,
+                root_resolution,
+                collapse_soma,
+                collapse_radius,
+            ]
+
+            if SkeletonService._check_root_id_against_refusal_list(bucket, datastack_name, rid):
+                missing.append(rid)
+                continue
+
+            h5_available = SkeletonService._confirm_skeleton_in_cache(params_cached, "h5")
+            if verbose_level >= 1:
+                SkeletonService.print(f"get_skeleton_token_by_datastack_and_rids() H5 availability for rid {rid}: {h5_available}")
+
+            if h5_available:
+                file_name = SkeletonService._get_skeleton_filename(*params_cached, "h5")
+                object_paths[rid] = skvn_prefix + file_name
+            else:
+                missing.append(rid)
+
+        # Generate a downscoped access token scoped to the skeleton prefix in this bucket
+        credentials, _ = google.auth.default()
+        availability_condition = google.auth.downscoped.AvailabilityCondition(
+            expression=f'resource.name.startsWith("projects/_/buckets/{bucket_name}/objects/{skvn_prefix}")',
+        )
+        access_boundary = google.auth.downscoped.AccessBoundary([
+            google.auth.downscoped.AccessBoundaryRule(
+                available_resource=f'//storage.googleapis.com/projects/_/buckets/{bucket_name}',
+                available_permissions=['inRole:roles/storage.objectViewer'],
+                availability_condition=availability_condition,
+            )
+        ])
+        downscoped_creds = google.auth.downscoped.Credentials(
+            source_credentials=credentials,
+            access_boundary=access_boundary,
+        )
+        downscoped_creds.refresh(google.auth.transport.requests.Request())
+
+        expiry_str = downscoped_creds.expiry.isoformat() if downscoped_creds.expiry else None
+
+        return {
+            "token": downscoped_creds.token,
+            "token_type": "Bearer",
+            "expiry": expiry_str,
+            "bucket": bucket_name,
+            "object_paths": {str(rid): path for rid, path in object_paths.items()},
+            "missing": missing,
+        }
+
     @staticmethod
     def get_meshwork_by_datastack_and_rid_async(
         datastack_name: str,

--- a/skeletonservice/datasets/service.py
+++ b/skeletonservice/datasets/service.py
@@ -2516,14 +2516,21 @@ class SkeletonService:
         bucket_name = parts[0]
         bucket_extra_prefix = (parts[1] + "/") if len(parts) > 1 else ""
 
+        if skeleton_version != HIGHEST_SKELETON_VERSION:
+            if verbose_level >= 1:
+                SkeletonService.print(
+                    f"get_skeleton_token_by_datastack() Skeleton version V{skeleton_version} was requested but caching only supports version V{HIGHEST_SKELETON_VERSION}, so that version will be used."
+                )
+            skeleton_version = HIGHEST_SKELETON_VERSION
+
         datastack_name_remapped = DATASTACK_NAME_REMAPPING[datastack_name] if datastack_name in DATASTACK_NAME_REMAPPING else datastack_name
-        skvn_prefix = f"{bucket_extra_prefix}{datastack_name_remapped}/{HIGHEST_SKELETON_VERSION}/"
+        skvn_prefix = f"{bucket_extra_prefix}{datastack_name_remapped}/{skeleton_version}/"
 
         # Build path template: client substitutes {rid} for each root ID
         template_params = [
             "{rid}",
             bucket,
-            HIGHEST_SKELETON_VERSION,
+            skeleton_version,
             datastack_name,
             root_resolution,
             collapse_soma,

--- a/tests/test_skeletonservice.py
+++ b/tests/test_skeletonservice.py
@@ -1,8 +1,10 @@
+import binascii
 import io
-from unittest.mock import patch
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
 import responses
 import pandas as pd
-from skeletonservice.datasets.service import SkeletonService
+from skeletonservice.datasets.service import MAX_BULK_CACHED_SKELETONS, SkeletonService
 from cloudfiles import CloudFiles
 from messagingclient import MessagingClientPublisher
 from caveclient import CAVEclient, endpoints
@@ -352,6 +354,197 @@ class TestSkeletonsService:
         )
 
         assert et == 60
+
+    # ------------------------------------------------------------------ #
+    # Tests for get_cached_skeletons_bulk_by_datastack_and_rids           #
+    # ------------------------------------------------------------------ #
+
+    def test_get_cached_skeletons_bulk_cache_hit(self, test_app):
+        """Cache hit: skeleton already stored in the requested format is returned hex-encoded."""
+        fake_bytes = b"fake_compressed_skeleton_data"
+
+        patch.object(SkeletonService, "_check_root_id_against_refusal_list", return_value=False).start()
+        patch.object(SkeletonService, "_retrieve_skeleton_from_cache", return_value=fake_bytes).start()
+
+        SkelClassVsn = SkeletonService.get_version_specific_handler(4)
+
+        result = SkelClassVsn.get_cached_skeletons_bulk_by_datastack_and_rids(
+            datastack_name=datastack_dict["datastack_name"],
+            rids=[1],
+            bucket="gs://test_bucket",
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=4,
+            output_format="flatdict",
+        )
+
+        assert 1 in result
+        assert result[1] == binascii.hexlify(fake_bytes).decode("ascii")
+
+    def test_get_cached_skeletons_bulk_cache_miss(self, test_app):
+        """Cache miss with no H5 available: RID is absent from the returned dict."""
+        patch.object(SkeletonService, "_check_root_id_against_refusal_list", return_value=False).start()
+        patch.object(SkeletonService, "_retrieve_skeleton_from_cache", return_value=None).start()
+        patch.object(SkeletonService, "_confirm_skeleton_in_cache", return_value=False).start()
+
+        SkelClassVsn = SkeletonService.get_version_specific_handler(4)
+
+        result = SkelClassVsn.get_cached_skeletons_bulk_by_datastack_and_rids(
+            datastack_name=datastack_dict["datastack_name"],
+            rids=[1],
+            bucket="gs://test_bucket",
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=4,
+            output_format="flatdict",
+            generate_missing_skeletons=False,
+        )
+
+        assert result == {}
+
+    def test_get_cached_skeletons_bulk_rid_truncation(self, test_app):
+        """RIDs beyond MAX_BULK_CACHED_SKELETONS are silently truncated."""
+        fake_bytes = b"fake_compressed_skeleton_data"
+
+        patch.object(SkeletonService, "_check_root_id_against_refusal_list", return_value=False).start()
+        patch.object(SkeletonService, "_retrieve_skeleton_from_cache", return_value=fake_bytes).start()
+
+        SkelClassVsn = SkeletonService.get_version_specific_handler(4)
+
+        oversized_rids = list(range(MAX_BULK_CACHED_SKELETONS + 10))
+
+        result = SkelClassVsn.get_cached_skeletons_bulk_by_datastack_and_rids(
+            datastack_name=datastack_dict["datastack_name"],
+            rids=oversized_rids,
+            bucket="gs://test_bucket",
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=4,
+            output_format="flatdict",
+        )
+
+        assert len(result) == MAX_BULK_CACHED_SKELETONS
+        assert (MAX_BULK_CACHED_SKELETONS + 9) not in result
+
+    def test_get_cached_skeletons_bulk_refusal_list(self, test_app):
+        """RIDs on the refusal list are excluded from the returned dict."""
+        def refusal_side_effect(bucket, datastack_name, rid):
+            return rid == 1
+
+        patch.object(SkeletonService, "_check_root_id_against_refusal_list", side_effect=refusal_side_effect).start()
+        patch.object(SkeletonService, "_retrieve_skeleton_from_cache", return_value=b"data").start()
+
+        SkelClassVsn = SkeletonService.get_version_specific_handler(4)
+
+        result = SkelClassVsn.get_cached_skeletons_bulk_by_datastack_and_rids(
+            datastack_name=datastack_dict["datastack_name"],
+            rids=[1, 2],
+            bucket="gs://test_bucket",
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=4,
+            output_format="flatdict",
+        )
+
+        assert 1 not in result
+        assert 2 in result
+
+    # ------------------------------------------------------------------ #
+    # Tests for get_skeleton_token_by_datastack                           #
+    # ------------------------------------------------------------------ #
+
+    def test_get_skeleton_token_returns_expected_keys(self, test_app):
+        """Token response contains all required keys."""
+        fake_token = "fake-access-token-abc123"
+        fake_expiry = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+        mock_downscoped_creds = MagicMock()
+        mock_downscoped_creds.token = fake_token
+        mock_downscoped_creds.expiry = fake_expiry
+
+        patch("google.auth.default", return_value=(MagicMock(), "test-project")).start()
+        patch("google.auth.downscoped.AvailabilityCondition", return_value=MagicMock()).start()
+        patch("google.auth.downscoped.AccessBoundaryRule", return_value=MagicMock()).start()
+        patch("google.auth.downscoped.AccessBoundary", return_value=MagicMock(), create=True).start()
+        patch("google.auth.downscoped.Credentials", return_value=mock_downscoped_creds).start()
+        patch("google.auth.transport.requests.Request", return_value=MagicMock()).start()
+
+        SkelClassVsn = SkeletonService.get_version_specific_handler(4)
+
+        result = SkelClassVsn.get_skeleton_token_by_datastack(
+            datastack_name=datastack_dict["datastack_name"],
+            bucket="gs://test_bucket",
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=4,
+        )
+
+        assert "token" in result
+        assert "token_type" in result
+        assert "expiry" in result
+        assert "bucket" in result
+        assert "path_template" in result
+        assert result["token"] == fake_token
+        assert result["token_type"] == "Bearer"
+        assert result["expiry"] == fake_expiry.isoformat()
+
+    def test_get_skeleton_token_path_template_contains_rid_placeholder(self, test_app):
+        """path_template must include a {rid} placeholder for client-side path construction."""
+        mock_downscoped_creds = MagicMock()
+        mock_downscoped_creds.token = "tok"
+        mock_downscoped_creds.expiry = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        patch("google.auth.default", return_value=(MagicMock(), "test-project")).start()
+        patch("google.auth.downscoped.AvailabilityCondition", return_value=MagicMock()).start()
+        patch("google.auth.downscoped.AccessBoundaryRule", return_value=MagicMock()).start()
+        patch("google.auth.downscoped.AccessBoundary", return_value=MagicMock(), create=True).start()
+        patch("google.auth.downscoped.Credentials", return_value=mock_downscoped_creds).start()
+        patch("google.auth.transport.requests.Request", return_value=MagicMock()).start()
+
+        SkelClassVsn = SkeletonService.get_version_specific_handler(4)
+
+        result = SkelClassVsn.get_skeleton_token_by_datastack(
+            datastack_name=datastack_dict["datastack_name"],
+            bucket="gs://test_bucket",
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=4,
+        )
+
+        assert "{rid}" in result["path_template"]
+
+    def test_get_skeleton_token_bucket_name_strips_scheme(self, test_app):
+        """Returned bucket key contains only the bare bucket name, not the gs:// scheme."""
+        mock_downscoped_creds = MagicMock()
+        mock_downscoped_creds.token = "tok"
+        mock_downscoped_creds.expiry = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        patch("google.auth.default", return_value=(MagicMock(), "test-project")).start()
+        patch("google.auth.downscoped.AvailabilityCondition", return_value=MagicMock()).start()
+        patch("google.auth.downscoped.AccessBoundaryRule", return_value=MagicMock()).start()
+        patch("google.auth.downscoped.AccessBoundary", return_value=MagicMock(), create=True).start()
+        patch("google.auth.downscoped.Credentials", return_value=mock_downscoped_creds).start()
+        patch("google.auth.transport.requests.Request", return_value=MagicMock()).start()
+
+        SkelClassVsn = SkeletonService.get_version_specific_handler(4)
+
+        result = SkelClassVsn.get_skeleton_token_by_datastack(
+            datastack_name=datastack_dict["datastack_name"],
+            bucket="gs://my-bucket-name",
+            root_resolution=[1, 1, 1],
+            collapse_soma=True,
+            collapse_radius=7500,
+            skeleton_version=4,
+        )
+
+        assert result["bucket"] == "my-bucket-name"
+        assert not result["bucket"].startswith("gs://")
 
     def test_generate_skeletons_bulk_by_datastack_and_rids_async(self, test_app, caveclient_mock, cloudvolume_mock):
         responses.add(responses.GET, url=info_url, json=test_info, status=200)


### PR DESCRIPTION
Addresses user reports of hitting the 10-skeleton limit in get_bulk_skeletons() even when all requested skeletons already exist in the GCS cache. The existing limit was designed to prevent blocking on skeleton generation, but incorrectly also throttled retrieval of pre-existing cached skeletons. This PR adds two new endpoints that separate those concerns.

Changes

POST /<datastack>/bulk/get_cached_skeletons/<skvn>/<output_format> — retrieves up to 500 already-cached skeletons per call. Skips per-RID is_valid_nodes() validation against the chunkedgraph (the main bottleneck of the existing endpoint). Returns a structured dict with three keys: skeletons (data for found RIDs), missing (not in cache), and async_queued (queued for async generation if generate_missing=true). Rate-limited by the new get_cached_skeletons_bulk category.

POST /<datastack>/bulk/get_skeleton_token/<skvn> — generates a short-lived, downscoped GCS OAuth2 Bearer token scoped to read-only access on the skeleton bucket prefix for the given datastack and version. The client can use this token to download skeleton H5 files directly from GCS without routing through this service, which is significantly faster for bulk access. Returns the token, expiry, bucket name, GCS object paths for each cached RID, and a list of missing RIDs.

New constants: MAX_BULK_CACHED_SKELETONS = 500

New dependencies: google.auth.downscoped (already available via google-auth)